### PR TITLE
Link static lib directly into .node, remove OSX hack.

### DIFF
--- a/templates/binding.gyp.hbs
+++ b/templates/binding.gyp.hbs
@@ -29,27 +29,20 @@ Required context:
 
         "variables": {
             "rust_inputs": [{{#each project.rust.inputs}}{{#unless @first}}, {{/unless}}"{{this}}"{{/each}}],
-            "static_lib": "target/{{build.cfg.cargo}}/<(STATIC_LIB_PREFIX){{project.name}}<(STATIC_LIB_SUFFIX)",
-            "shared_lib": "target/{{build.cfg.cargo}}/<(SHARED_LIB_PREFIX){{project.name}}<(SHARED_LIB_SUFFIX)"
+            "static_lib": "target/{{build.cfg.cargo}}/<(STATIC_LIB_PREFIX){{project.name}}<(STATIC_LIB_SUFFIX)"
         },
 
         "sources": ["<(INTERMEDIATE_DIR)/binding.cc"],      {{~! built client-side }}
 
         "include_dirs": ["<!(neon include-path)"],          {{~! computed client-side }}
 
-        "libraries": ["../<(shared_lib)"],                  {{~! gyp weirdly determines libraries from a subdirectory so ../ is needed }}
+        "libraries": ["../<(static_lib)"],                  {{~! gyp weirdly determines libraries from a subdirectory so ../ is needed }}
 
         "actions": [{
             "action_name": "cargo",
             "inputs": ["<@(rust_inputs)"],
             "outputs": ["../<(static_lib)"],
             "action": [{{#each build.cargo.cmd}}"{{this}}", {{/each}}"cargo", "rustc", {{#if build.release}}"--release", {{/if}}"--", "--crate-type", "staticlib"]
-        }, {
-            "action_name": "shared_lib",
-            "inputs": ["<(static_lib)"],
-            "outputs": ["../<(shared_lib)"],
-            # FIXME: OSX-specific
-            "action": ["gcc", "-dynamiclib", "-Wl,-undefined,dynamic_lookup", "-Wl,-force_load,<(static_lib)", "-o", "<(shared_lib)"]
         }, {
             "action_name": "generate",
             "inputs": [],


### PR DESCRIPTION
Should allow building on all architectures supported by Node.js and Rust.
Tested that it builds and loads fine on Linux.
