### PR TITLE
Support npm scoped packages

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,7 +29,7 @@ case 'new':
 function printUsage() {
   console.log("Usage:");
   console.log();
-  console.log("  neon new <name> [--rust|-r nightly|stable|default]");
+  console.log("  neon new [@scope/]<name> [--rust|-r nightly|stable|default]");
   console.log("    create a new Neon project");
   console.log();
   console.log("  neon help");


### PR DESCRIPTION
There is a [scoped package](https://docs.npmjs.com/misc/scope) in npm and `npm init` supported a scope option: https://docs.npmjs.com/cli/init#scope

I support the scope option in neon new by same way with npm like [this](https://github.com/npm/init-package-json/pull/31).

e.g.

```
$ neon new my-project --scope=@me
This utility will walk you through creating a Neon project.
It only covers the most common items, and tries to guess sensible defaults.

Press ^C at any time to quit.
? name @me/my-project
...follow prompts...

$ cat my-project/package.json
{
  "name": "@me/my-project",
  "version": "0.1.0",
  "description": "An example for #11 on dherman/neon-cli",
  "main": "lib/index.js",
  "scripts": {
    "postinstall": "neon build"
  },
  "author": "Daijiro Wachi <daijiro.wachi@gmail.com>",
  "license": "MIT",
  "dependencies": {
    "neon-cli": "^0.1.1",
    "neon-bridge": "^0.1.2"
  }
}
```
