### PR TITLE
neon version and print the version in the usage

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+var path = require('path')
 var minimist = require('minimist');
+var pkg = require(path.resolve(__dirname, '../package.json'));
 
 if (process.argv.length < 3) {
   printUsage();
@@ -12,6 +14,9 @@ var args = minimist(process.argv.slice(3));
 var pwd = process.cwd();
 
 switch (command) {
+case 'version':
+  console.log(pkg.version)
+  break;
 case 'help':
   printUsage();
   break;
@@ -27,6 +32,7 @@ case 'new':
 }
 
 function printUsage() {
+  console.log();
   console.log("Usage:");
   console.log();
   console.log("  neon new <name> [--rust|-r nightly|stable|default]");
@@ -35,4 +41,8 @@ function printUsage() {
   console.log("  neon help");
   console.log("    print this usage information");
   console.log();
+  console.log("  neon version");
+  console.log("    print neon-cli version");
+  console.log();
+  console.log("neon-cli@" + pkg.version + " " + path.dirname(__dirname));
 }

--- a/test/acceptance/help.js
+++ b/test/acceptance/help.js
@@ -8,6 +8,7 @@ describe('neon help', function() {
         .wait('Usage:')
         .wait('neon new')
         .wait('neon help')
+        .wait('neon version')
         .run(err => {
           if (err) throw err;
           done();

--- a/test/acceptance/version.js
+++ b/test/acceptance/version.js
@@ -1,0 +1,17 @@
+import { setup } from '../support/acceptance';
+import { readFile } from '../support/fs';
+
+const pkg = JSON.parse(readFile(__dirname, '../../package.json'));
+
+describe('neon version', function() {
+  setup();
+
+  it('should print neon usage', function(done) {
+    this.spawn(['version'])
+        .wait(pkg.version)
+        .run(err => {
+          if (err) throw err;
+          done();
+        });
+  });
+});


### PR DESCRIPTION
Fixes #13.

```
$ neon help

Usage:

  neon new <name> [--rust|-r nightly|stable|default]
    create a new Neon project

  neon help
    print this usage information

  neon version
    print neon-cli version

neon-cli@0.1.3 /Users/watilde/Development/neon-cli

$ neon version
0.1.3

```
