### PR TITLE
Ensure `guessAuthor` returns object with `name`

### DIFF
--- a/src/ops/neon_new.js
+++ b/src/ops/neon_new.js
@@ -28,7 +28,7 @@ const README_TEMPLATE    = compile('README.md.hbs');
 
 async function guessAuthor() {
   let author = {
-    author: process.env.USER || process.env.USERNAME,
+    name: process.env.USER || process.env.USERNAME,
     email: undefined
   };
   try {
@@ -80,7 +80,7 @@ export default async function wizard(pwd, name, toolchain) {
     { type: 'input', name: 'description', message: "description"                                              },
     { type: 'input', name: 'node',        message: "node entry point", default: "lib" + path.sep + "index.js" },
     { type: 'input', name: 'git',         message: "git repository"                                           },
-    { type: 'input', name: 'author',      message: "author",           default: guess.author                  },
+    { type: 'input', name: 'author',      message: "author",           default: guess.name                    },
     { type: 'input', name: 'email',       message: "email",            default: guess.email                   },
     {
       type: 'input',


### PR DESCRIPTION
The `guessAuthor` function was accidentally returning an object with both `author` and `name` properties set (to `process.env.USER || process.env.USERNAME` and the value of git's `user.name` config, respectively). This commit ensures that the object returned from `guessAuthor` will always be an object with only the `name` and `email` keys, that it will prefer the git config `user.name` property when it can find it, and that the default value for the "author" prompt in the `neon new` flow will be the name returned from `guessAuthor`.

This fixes a problem where the `process.env.USER || process.env.USERNAME` value was always used as the default for the "auther" prompt in `neon new`, even if there was a git config `user.name` setting available.
