### PR TITLE
add npm start and build scripts

### DIFF
--- a/templates/package.json.hbs
+++ b/templates/package.json.hbs
@@ -19,6 +19,8 @@
     "neon-cli": "^{{neon-cli.major}}.{{neon-cli.minor}}.{{neon-cli.patch}}"
   },
   "scripts": {
+    "start": "node lib/index.js",
+    "build": "neon build",
     "install": "neon build"
   }
 }


### PR DESCRIPTION
Using `$ npm start` is more eloquent/ergonomic than the suggested `$ node -e "require('.')"`.

Also, when we want to build/rebuild our rust code we can simply `$ npm run build`.