### PR TITLE
Add documentation for the build command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,9 @@ function printUsage() {
   console.log("  neon new [@<scope>/]<name> [--rust|-r nightly|stable|default]");
   console.log("    create a new Neon project");
   console.log();
+  console.log("  neon build [--rust|-r nightly|stable|default] [--debug|-d]");
+  console.log("    rebuild the project");
+  console.log();
   console.log("  neon version");
   console.log("    print neon-cli version");
   console.log();


### PR DESCRIPTION
When I was trying to figure out to rebuild, I expected to find the command using `neon help`. Apologies if I missed existing documentation in another location.