### PR TITLE
Roll back #37 for now

### DIFF
--- a/src/ops/neon_build.js
+++ b/src/ops/neon_build.js
@@ -36,9 +36,15 @@ function cargo(toolchain, configuration, nodeModuleVersion) {
                            configuration === 'release' ? ["--release"] : [],
                            macos ? ["--", "-C", "link-args=-Wl,-undefined,dynamic_lookup"] : []);
 
+  // Save the current Node ABI version as an environment variable.
+  let env = clone(process.env);
+  if (nodeModuleVersion) {
+    env.NEON_NODE_ABI = nodeModuleVersion;
+  }
+
   console.log(style.info([command].concat(args).join(" ")));
 
-  return spawn(command, args, { cwd: 'native', stdio: 'inherit' });
+  return spawn(command, args, { cwd: 'native', stdio: 'inherit', env: env });
 }
 
 async function main(name, configuration) {


### PR DESCRIPTION
I'll file an issue to eliminate the NEON_NODE_ABI environment variable as part of the 0.2 release, whenever that happens. For now it doesn't really hurt to keep compatibility.