### PR TITLE
Windows support

### DIFF
--- a/src/ops/neon_build.js
+++ b/src/ops/neon_build.js
@@ -36,13 +36,9 @@ function cargo(toolchain, configuration) {
                            configuration === 'release' ? ["--release"] : [],
                            macos ? ["--", "-C", "link-args=-Wl,-undefined,dynamic_lookup"] : []);
 
-  // Save the current Node ABI version as an environment variable.
-  let env = clone(process.env);
-  env.NEON_NODE_ABI = process.versions.modules;
-
   console.log(style.info([command].concat(args).join(" ")));
 
-  return spawn(command, args, { cwd: 'native', stdio: 'inherit', env: env });
+  return spawn(command, args, { cwd: 'native', stdio: 'inherit' });
 }
 
 async function main(name, configuration) {

--- a/src/ops/neon_build.js
+++ b/src/ops/neon_build.js
@@ -25,11 +25,12 @@ const LIB_SUFFIX = {
   'win32':   ".dll"
 };
 
-function rust_target_for_npm_arch_flag(arch) {
+function explicit_cargo_target() {
   if (process.platform === 'win32') {
+    let arch = process.env.npm_config_arch || process.arch;
     if (arch === 'ia32') {
       return 'i686-pc-windows-msvc';
-    } else if (arch === 'x64') {
+    } else {
       return 'x86_64-pc-windows-msvc';
     }
   }
@@ -77,9 +78,7 @@ export default async function neon_build(pwd, toolchain, configuration) {
     throw new Error("Cargo.toml does not contain a [lib] section with a 'name' field");
   }
 
-  let target = process.env.npm_config_arch ?
-    rust_target_for_npm_arch_flag(process.env.npm_config_arch) :
-    null;
+  let target = explicit_cargo_target();
 
   console.log(style.info("running cargo"));
 

--- a/src/ops/neon_build.js
+++ b/src/ops/neon_build.js
@@ -47,7 +47,7 @@ function cargo(toolchain, configuration, nodeModuleVersion, target) {
                            configuration === 'release' ? ["--release"] : [],
                            macos ? ["--", "-C", "link-args=-Wl,-undefined,dynamic_lookup"] : []);
 
-  // Save the current Node ABI version as an environment variable.
+  // Pass the Node modules ABI version to the build as an environment variable.
   let env = clone(process.env);
   env.NEON_NODE_ABI = nodeModuleVersion || process.versions.modules;
 

--- a/src/ops/neon_build.js
+++ b/src/ops/neon_build.js
@@ -25,7 +25,17 @@ const LIB_SUFFIX = {
   'win32':   ".dll"
 };
 
-function cargo(toolchain, configuration) {
+function rust_target_for_npm_arch_flag(arch) {
+  if (process.platform === 'win32') {
+    if (arch === 'ia32') {
+      return 'i686-pc-windows-msvc';
+    } else if (arch === 'x64') {
+      return 'x86_64-pc-windows-msvc';
+    }
+  }
+}
+
+function cargo(toolchain, configuration, target) {
   let macos = process.platform === 'darwin';
 
   let [command, prefix] = toolchain === 'default'
@@ -36,14 +46,21 @@ function cargo(toolchain, configuration) {
                            configuration === 'release' ? ["--release"] : [],
                            macos ? ["--", "-C", "link-args=-Wl,-undefined,dynamic_lookup"] : []);
 
+  if (target) {
+    args.push("--target=" + target);
+  }
+
   console.log(style.info([command].concat(args).join(" ")));
 
   return spawn(command, args, { cwd: 'native', stdio: 'inherit' });
 }
 
-async function main(name, configuration) {
+async function main(name, configuration, target) {
   let pp = process.platform;
-  let dylib = path.resolve('native', 'target', configuration, LIB_PREFIX[pp] + name + LIB_SUFFIX[pp]);
+  let output_directory = target ?
+    path.resolve('native', 'target', target, configuration) :
+    path.resolve('native', 'target', configuration);
+  let dylib = path.resolve(output_directory, LIB_PREFIX[pp] + name + LIB_SUFFIX[pp]);
   let index = path.resolve('native', 'index.node');
 
   console.log(style.info("generating native" + path.sep + "index.node"));
@@ -60,13 +77,17 @@ export default async function neon_build(pwd, toolchain, configuration) {
     throw new Error("Cargo.toml does not contain a [lib] section with a 'name' field");
   }
 
+  let target = process.env.npm_config_arch ?
+    rust_target_for_npm_arch_flag(process.env.npm_config_arch) :
+    null;
+
   console.log(style.info("running cargo"));
 
   // 2. Build the binary.
-  if ((await cargo(toolchain, configuration)) !== 0) {
+  if ((await cargo(toolchain, configuration, target)) !== 0) {
     throw new Error("cargo build failed");
   }
 
   // 3. Copy the dylib into the main index.node file.
-  await main(metadata.lib.name, configuration);
+  await main(metadata.lib.name, configuration, target);
 }

--- a/src/ops/neon_new.js
+++ b/src/ops/neon_new.js
@@ -25,6 +25,7 @@ const NPM_TEMPLATE       = compile('package.json.hbs');
 const INDEXJS_TEMPLATE   = compile('index.js.hbs');
 const LIBRS_TEMPLATE     = compile('lib.rs.hbs');
 const README_TEMPLATE    = compile('README.md.hbs');
+const BUILDRS_TEMPLATE    = compile('build.rs.hbs');
 
 async function guessAuthor() {
   let author = {
@@ -139,6 +140,7 @@ export default async function wizard(pwd, name, toolchain) {
   await writeFile(path.resolve(root,    'README.md'),    (await README_TEMPLATE)(ctx),    { flag: 'wx' });
   await writeFile(path.resolve(root,    answers.node),   (await INDEXJS_TEMPLATE)(ctx),   { flag: 'wx' });
   await writeFile(path.resolve(src,     'lib.rs'),       (await LIBRS_TEMPLATE)(ctx),     { flag: 'wx' });
+  await writeFile(path.resolve(native_, 'build.rs'),     (await BUILDRS_TEMPLATE)(ctx),   { flag: 'wx' });
 
   let relativeRoot = path.relative(pwd, root);
   let relativeNode = path.relative(pwd, path.resolve(root, answers.node));

--- a/src/ops/neon_new.js
+++ b/src/ops/neon_new.js
@@ -25,7 +25,7 @@ const NPM_TEMPLATE       = compile('package.json.hbs');
 const INDEXJS_TEMPLATE   = compile('index.js.hbs');
 const LIBRS_TEMPLATE     = compile('lib.rs.hbs');
 const README_TEMPLATE    = compile('README.md.hbs');
-const BUILDRS_TEMPLATE    = compile('build.rs.hbs');
+const BUILDRS_TEMPLATE   = compile('build.rs.hbs');
 
 async function guessAuthor() {
   let author = {

--- a/templates/build.rs.hbs
+++ b/templates/build.rs.hbs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    if cfg!(windows) {
+        let debug = env::var("DEBUG").ok().map_or(false, |s| s == "true");
+        let configuration = if debug { "Debug" } else { "Release" };
+        let node_root_dir = env::var("DEP_NEON_SYS_NODE_ROOT_DIR").unwrap();
+        println!("cargo:rustc-link-lib=node");
+        println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
+    }
+}

--- a/templates/build.rs.hbs
+++ b/templates/build.rs.hbs
@@ -5,7 +5,8 @@ fn main() {
         let debug = env::var("DEBUG").ok().map_or(false, |s| s == "true");
         let configuration = if debug { "Debug" } else { "Release" };
         let node_root_dir = env::var("DEP_NEON_SYS_NODE_ROOT_DIR").unwrap();
-        println!("cargo:rustc-link-lib=node");
+        let node_lib_file = env::var("DEP_NEON_SYS_NODE_LIB_FILE").unwrap();
         println!("cargo:rustc-link-search={}\\{}", node_root_dir, configuration);
+        println!("cargo:rustc-link-lib={}", node_lib_file);
     }
 }


### PR DESCRIPTION
Pulled out from #32, minus the part that actually eliminates the environment variable. Leaving that in for now for compatibility; we can eliminate it whenever we update to 0.2.