### PR TITLE
Finish windows

### DIFF
--- a/src/ops/neon_new.js
+++ b/src/ops/neon_new.js
@@ -78,11 +78,11 @@ export default async function wizard(pwd, name, toolchain) {
         return "Invalid version: " + input;
       }
     },
-    { type: 'input', name: 'description', message: "description"                                              },
-    { type: 'input', name: 'node',        message: "node entry point", default: "lib" + path.sep + "index.js" },
-    { type: 'input', name: 'git',         message: "git repository"                                           },
-    { type: 'input', name: 'author',      message: "author",           default: guess.name                    },
-    { type: 'input', name: 'email',       message: "email",            default: guess.email                   },
+    { type: 'input', name: 'description', message: "description"                               },
+    { type: 'input', name: 'node',        message: "node entry point", default: "lib/index.js" },
+    { type: 'input', name: 'git',         message: "git repository"                            },
+    { type: 'input', name: 'author',      message: "author",           default: guess.name     },
+    { type: 'input', name: 'email',       message: "email",            default: guess.email    },
     {
       type: 'input',
       name: 'license',

--- a/templates/Cargo.toml.hbs
+++ b/templates/Cargo.toml.hbs
@@ -7,6 +7,7 @@ authors = ["{{project.author}}{{#if project.email}} <{{project.email}}>{{/if}}"]
 {{#if project.license}}
 license = "{{project.license}}"
 {{/if}}
+build = "build.rs"
 
 [lib]
 name = "{{project.name.cargo.internal}}"


### PR DESCRIPTION
Last couple of tweaks needed to make Windows builds work: the `build.rs` script has to be added to `Cargo.toml`, and `"lib\index.js"` was improperly escaped but should just be `"lib/index.js"` to be more portable anyway.