### PR TITLE
Fix `neon build` when run without arguments

### DIFF
--- a/packages/neon-cli/cli.ts
+++ b/packages/neon-cli/cli.ts
@@ -37,7 +37,7 @@ function logIf(multiple: boolean, action: string, cwd: string, module: string) {
 }
 
 function parseModules(cwd: string, names: string[], paths: string[]) {
-  let modules = names
+  let modules = names.length > 0
       ? names.map(m => paths ? path.resolve(cwd, m)
                              : path.resolve(cwd, 'node_modules', m))
       : [cwd];


### PR DESCRIPTION
`neon build` did no longer build the module from the `native` sub-directory
automatically. This breaking change was introduced in version 0.1.14 with
commit 42726bded444be5a2e228c8faa3128f9dcd01db5 [1].

The problem is the ternary operator. It doesn't evaluate as expected. An
empty array evaluate as `true` (same as for an `if` statement):

    > [] ? true : false;
    true

Therefore an empty list of modules evaluated to `true` and the code tried
to resolve their paths, which lead again to an empty array, which lead
to not building anything at all.

The fix is to check for the length of the array.

[1]: https://github.com/neon-bindings/neon-cli/commit/42726bded444be5a2e228c8faa3128f9dcd01db5#diff-d9d9214113dea1c364abd4ba3c70be11R141