### PR TITLE
Move ts-typed-json to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rsvp": "^3.1.0",
     "semver": "^5.1.0",
     "toml": "^2.3.0",
+    "ts-typed-json": "^0.2.2",
     "validate-npm-package-license": "^3.0.1",
     "validate-npm-package-name": "^2.2.2"
   },
@@ -51,7 +52,6 @@
     "tmp": "0.0.28",
     "ts-dict": "^0.1.1",
     "ts-node": "^3.0.2",
-    "ts-typed-json": "^0.2.2",
     "typescript": "^2.2.2"
   },
   "scripts": {


### PR DESCRIPTION
With version 0.1.16, when I run `npm i -g neon-cli` and then `neon build`, I get the following error:
```
module.js:472
    throw err;
    ^

Error: Cannot find module 'ts-typed-json'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
...
```

This commit moves the affected module to the production dependencies and thus fixes the error.