### PR TITLE
use overloading for proper type for readFile

### DIFF
--- a/packages/neon-cli/async/fs.ts
+++ b/packages/neon-cli/async/fs.ts
@@ -7,9 +7,14 @@ import mkdirp = require('mkdirp');
 export let stat: (path: string) => Promise<fs.Stats>
   = RSVP.denodeify(fs.stat);
 
-export let readFile: ((path: string, options: { encoding: string; flag?: string; }) => Promise<string>)
-                   & ((path: string) => Promise<Buffer>)
+let rf: (path: string, options?: { encoding: string; flag?: string; }) => Promise<string | Buffer>
   = RSVP.denodeify<string | Buffer>(fs.readFile);
+
+export function readFile(path: string, options: { encoding: string; flag?: string; }): Promise<string>;
+export function readFile(path: string): Promise<Buffer>;
+export function readFile(path: string, options?: { encoding: string; flag?: string; }): Promise<string | Buffer> {
+  return rf(path, options);
+}
 
 export type WriteOptions = {
   encoding?: string,

--- a/packages/neon-cli/project.ts
+++ b/packages/neon-cli/project.ts
@@ -18,7 +18,7 @@ export default class Project {
   constructor(root: string, options: ProjectOptions = {}) {
     let { crate = 'native' } = options;
     this.root = root;
-    this.crate = new Crate(this, crate);
+    this.crate = new Crate(this, { subdirectory: crate });
   }
 
   async build(toolchain: rust.Toolchain,


### PR DESCRIPTION
Updating to recent TS version causes a type error in the readFile signature. This fixes it using a more accurate overloading.