### PR TITLE
Update to work with the @types/rsvp upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/nexpect": "^0.4.29",
     "@types/node": "^7.0.13",
     "@types/rimraf": "0.0.28",
-    "@types/rsvp": "^3.3.0",
+    "@types/rsvp": "^3.3.1",
     "@types/semver": "^5.3.31",
     "@types/tmp": "0.0.32",
     "chai": "^3.4.1",

--- a/packages/neon-cli/async/fs.ts
+++ b/packages/neon-cli/async/fs.ts
@@ -1,14 +1,14 @@
 import * as fs from 'fs';
 import quicklyCopyFile = require('quickly-copy-file');
-import RSVP = require('rsvp');
+import RSVP from 'rsvp';
 import rimraf = require('rimraf');
 import mkdirp = require('mkdirp');
 
 export let stat: (path: string) => Promise<fs.Stats>
-  = RSVP.denodeify(fs.stat);
+  = RSVP.denodeify(fs.stat, false);
 
 let rf: (path: string, options?: { encoding: string; flag?: string; }) => Promise<string | Buffer>
-  = RSVP.denodeify<string | Buffer>(fs.readFile);
+  = RSVP.denodeify(fs.readFile, false);
 
 export function readFile(path: string, options: { encoding: string; flag?: string; }): Promise<string>;
 export function readFile(path: string): Promise<Buffer>;
@@ -23,12 +23,12 @@ export type WriteOptions = {
 };
 
 export let writeFile: (path: string, contents: string, options: WriteOptions) => Promise<void>
-  = RSVP.denodeify<void>(fs.writeFile);
+  = RSVP.denodeify(fs.writeFile, false);
 
 export let copy = quicklyCopyFile;
 
 export let remove: (path: string) => Promise<void>
-  = RSVP.denodeify<void>(rimraf);
+  = RSVP.denodeify(rimraf, false);
 
 export let mkdirs: (path: string) => Promise<void>
-  = RSVP.denodeify<void>(mkdirp);
+  = RSVP.denodeify(mkdirp, false);

--- a/packages/neon-cli/async/git-config.ts
+++ b/packages/neon-cli/async/git-config.ts
@@ -1,7 +1,7 @@
-import * as RSVP from 'rsvp';
+import RSVP from 'rsvp';
 import gitconfig = require('git-config');
 
 let gc: () => Promise<gitconfig.Dict>
-  = RSVP.denodeify<gitconfig.Dict>(gitconfig);
+  = RSVP.denodeify(gitconfig, false);
 
 export default gc;


### PR DESCRIPTION
The @types/rsvp upgrade from 3.3.0 -> 3.3.1 was, AFAICT, incompatible (ouch)!